### PR TITLE
Overrides remote_ip in development

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
     if Rails.env.development?
       ActionDispatch::Request.class_eval do
         def remote_ip
-          Rails.application.secrets[:dev_ip]
+          '74.115.209.58'
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   include SessionsHelper
 
+  before_filter :development_ip
+
 
   def correct_user
   	begin
@@ -20,5 +22,14 @@ class ApplicationController < ActionController::Base
   def time_now
   	t = Time.now
   	# Time.new(2000,1,1,t.hour,t.min,t.sec)
+  end
+  def development_ip
+    if Rails.env.development?
+      ActionDispatch::Request.class_eval do
+        def remote_ip
+          Rails.application.secrets[:dev_ip]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Addresses #16 

In order to verify that geocoder is functioning correctly, we need to provide an appropriate ip address in development. This commit adds a before_filter in ApplicationController that monkeypatches the request.remote_ip method if Rails.env.development?. 