### PR TITLE
Overrides ActionDispatch to return appropriate ip address

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   include SessionsHelper
 
+  before_filter :development_ip
+
 
   def correct_user
   	begin
@@ -20,5 +22,18 @@ class ApplicationController < ActionController::Base
   def time_now
   	t = Time.now
   	# Time.new(2000,1,1,t.hour,t.min,t.sec)
+  end
+  def development_ip
+    if Rails.env.development?
+      ActionDispatch::Request.class_eval do
+        def remote_ip
+          uri = URI.parse('http://api.ipify.org?format=json')
+          http = Net::HTTP.new(uri.host, uri.port)
+
+          request = Net::HTTP::Get.new(uri.request_uri)
+          response = JSON.parse(http.request(request).body)["ip"]
+        end
+      end
+    end
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,5 +24,6 @@ html
 
 - if Rails.env.development?
   hr
+  = debug(request.remote_ip)
   = debug(params)
   / = debug(request.env)


### PR DESCRIPTION
Addresses #16 

Opts for fetching developer's ip via [ipify's](https://www.ipify.org/) API instead of hardcoded address.