### PR TITLE
Adds verifications to geolocation ajax call

### DIFF
--- a/app/assets/javascripts/geoshiz.js
+++ b/app/assets/javascripts/geoshiz.js
@@ -33,7 +33,8 @@
 		$('.lcontent').append('<p class="error">An error occurred mapping your geolocation.<br /><br />' + e + '	</p>');
 	}
 
-
-$(function() {
-	coaster_enable_geolocation();
-});
+if ( $('#user_id').val() != undefined) {
+	$(function() {
+		coaster_enable_geolocation();
+	});
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_filter :signed_in_user, only: [:edit, :update, :index, :destroy]
-  before_filter :correct_user,   only: [:edit, :update, :show]
+  before_filter :signed_in_user, only: [:edit, :update, :index, :destroy, :update_geolocation]
+  before_filter :correct_user,   only: [:edit, :update, :show, :update_geolocation]
   before_filter :admin_user,     only: :destroy
   skip_before_filter :verify_authenticity_token, :only => [:update_geolocation]
 


### PR DESCRIPTION
Addresses #26 

1. Only calls ```coaster_enable_geolocation``` if ```$('#user_id').val() != undefined)```
2. Adds ```:update_geolocation``` to user verification ```before_filters```