### PR TITLE
WIP Sets secret_token per > Rails 4.1 conventions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ rvm:
 sudo: false
 before_script:
   - bundle exec rake db:migrate
+  - cp config/secrets.yml.example config/secrets.yml

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Coaster::Application.config.secret_token = 'd1c10ddcb42aaed2072f25f713145814a71f0148096c0499dfe009f36cc012787288ca20b6352e2eed69554253cbb668e12b60e0691cd26fd46cb3b9988d163d'

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,6 +1,8 @@
 development:
   google_key: YOUR GOOGLE API KEY
+  secret_token: YOUR SESSION SECRET
 
 production:
 
 test:
+  secret_token: '4038e98c8b1c1b101fc1cc78c7e14f9f7257517052fca5c1953d986d455ffdc0e5a313eb947da45ccc98fd1e75a1a8cebee4c69c3e5368ceb727d48d3592bf7f'


### PR DESCRIPTION
Addresses #28 

1. Removes secret_token.rb
2. Generates new token
3. Adds token to secrets.yml
4. Adds :test token to secrets.yml.example 
5. ```before_script cp secrets.yml.example secrets.yml``` in travis.yml