### PR TITLE
[Issue #12] Updates stack to cedar-14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ coverage
 /.ssh
 .DS_Store
 /public/assets
-/config/secrets.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,3 @@ notifications:
   email: false
 before_script:
   - bundle exec rake db:migrate
-  - cp config/secrets.yml.example config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby ENV['CUSTOM_RUBY_VERSION'] || '2.1.3'
 
 gem 'rails', '~> 4.2.5.1'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,5 +28,7 @@ Coaster::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  config.assets.quiet = true
+
   config.eager_load = false
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,11 +1,11 @@
 development:
   google_maps_api_key: YOUR GOOGLE API KEY
-  secret_token: rake secret
+  secret_key_base: rake secret
 
 production:
   google_maps_api_key: <%= ENV['GOOGLE_MAPS_API_KEY'] %>
-  secret_token: <%= ENV['SECRET_TOKEN'] %>
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
 
 test:
   google_maps_api_key: YOUR GOOGLE API KEY
-  secret_token: rake secret
+  secret_key_base: rake secret

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,11 @@
+development:
+  google_maps_api_key: YOUR GOOGLE API KEY
+  secret_token: rake secret
+
+production:
+  google_maps_api_key: <%= ENV['GOOGLE_MAPS_API_KEY'] %>
+  secret_token: <%= ENV['SECRET_TOKEN'] %>
+
+test:
+  google_maps_api_key: YOUR GOOGLE API KEY
+  secret_token: rake secret

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,8 +1,0 @@
-development:
-  google_key: YOUR GOOGLE API KEY
-  secret_token: YOUR SESSION SECRET
-
-production:
-
-test:
-  secret_token: '4038e98c8b1c1b101fc1cc78c7e14f9f7257517052fca5c1953d986d455ffdc0e5a313eb947da45ccc98fd1e75a1a8cebee4c69c3e5368ceb727d48d3592bf7f'


### PR DESCRIPTION
Adds necessary config for latest heroku stack.
Removes .example secrets.yml file

The reason for the convention of .example secrets files is so that you can change your local secrets.yml file without worry of accidental commit. Now that we have removed secrets.yml from our .gitignore, there is a _chance_ that accidental changes to secrets.yml will make it in to a commit. I would recommend adding secrets.yml to your local `.git/info/exclude` to avoid accidental commits to this file. Just remember to _remove_ the exclusion when you need to push updates to the secrets.yml file. 