### PR TITLE
[Issue #45 ] Makes geolocations dependent on :destroy

### DIFF
--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -16,7 +16,7 @@
 class Station < ActiveRecord::Base
   # attr_accessible :address, :city, :name, :state, :zip, :zone
   belongs_to :zone
-  has_one :geolocation, :as => :geocodeable
+  has_one :geolocation, :as => :geocodeable, dependent: :destroy
   has_many :trains
   before_save :set_geolocation
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
   validates :password, length: { minimum: 6 }, :if => :should_validate_password?
   validates :password_confirmation, presence: true,  :if => :should_validate_password?
 
-  has_one :geolocation, :as => :geocodeable
+  has_one :geolocation, :as => :geocodeable, dependent: :destroy
 
   has_many :destinations
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
 
   has_one :geolocation, :as => :geocodeable, dependent: :destroy
 
-  has_many :destinations
+  has_many :destinations, dependent: :destroy
 
   private
     def create_remember_token


### PR DESCRIPTION
Addresses #46 
Simply adds ```dependent: :destroy``` to the has_one methods on User and Station models. 